### PR TITLE
Fix spacing for non ref pub; Do not display project if empty

### DIFF
--- a/layouts/partials/projects.html
+++ b/layouts/partials/projects.html
@@ -1,4 +1,5 @@
 <div class="introduction">
+	{{ with .Site.Params.projects }}
 	<h4>Projects</h4>
 	<ul>
 		{{- range $index, $projects_map := .Site.Params.projects -}}
@@ -30,4 +31,5 @@
 
 		{{- end -}}
 	</ul>
+	{{ end }}
 </div>

--- a/layouts/partials/publications.html
+++ b/layouts/partials/publications.html
@@ -10,7 +10,7 @@
 			{{ if $publication.link }}
 			<a href="{{ $publication.link }}" class="publications"> {{ $publication.name }}, </a>
 			{{ else }}
-			<p class="publications">{{ $publication.name }},</p>
+			<p class="publications"> {{ $publication.name }}, </p>
 			{{ end }}
 			{{ $publication.dest | markdownify }}.
 


### PR DESCRIPTION
Hello,

Found a small misalignment bug in publication without link.
I also enclosed the projects section in a conditional.

Feel free to discard if you didn't want any of those changes.