### PR TITLE
Single page template and fix to references

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html>
-    {{- partial "head.html" . -}}
+    {{ partial "header.html" . }}    
     <body>
-        {{- partial "header.html" . -}}
         <div id="content">
-        {{- block "main" . }}{{- end }}
+        {{ block "main" . }}{{end}}
         </div>
-        {{- partial "footer.html" . -}}
+        {{ partial "footer.html" . }}
     </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+
+    <div class="header">
+        <img src="logo.png" class="logo">
+    </div>
+
+    <div class="content wrapper">
+        {{ .Content | markdownify }}
+    </div>
+    
+{{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,11 +9,11 @@
 	<title>{{ $title }} - {{ $siteTitle }}</title>
 	{{- end -}}
 
-	<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-	<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
-	<link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
-	<link rel="manifest" href="site.webmanifest">
-	<link rel="mask-icon" href="safari-pinned-tab.svg" color="#5bbad5">
+	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+	<link rel="manifest" href="/site.webmanifest">
+	<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 	<meta name="msapplication-TileColor" content="#da532c">
 	<meta name="theme-color" content="#ffffff">
 
@@ -26,13 +26,13 @@
 	{{- template "_internal/twitter_cards.html" . -}}
 	<link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,300italic,400italic|Raleway:500,100,300" rel="stylesheet">
 
-	<link rel="stylesheet" type="text/css" media="screen" href="css/normalize.css" />
-	<link rel="stylesheet" type="text/css" media="screen" href="css/main.css" />
+	<link rel="stylesheet" type="text/css" media="screen" href="/css/normalize.css" />
+	<link rel="stylesheet" type="text/css" media="screen" href="/css/main.css" />
 
 	{{- if and (isset .Site.Params "social") (isset .Site.Params "feathericonscdn") (eq .Site.Params.featherIconsCDN true) -}}
 	<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
 	{{- else if (isset .Site.Params "social") -}}
-	<script src="js/feather.min.js"></script>
+	<script src="/js/feather.min.js"></script>
 	{{- end -}}
-	<script src="js/main.js"></script>
+	<script src="/js/main.js"></script>
 </head>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -207,6 +207,15 @@ ul {
   /* float: left; */
 }
 
+.header .logo {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 15%;
+  height: auto;
+  border-radius: 50%;
+}
+
 .header h1,
 .header h2 {
   margin: 0;


### PR DESCRIPTION
**Update**: add a single page template.
I have added a single pate template to the theme. It can be used for an additional single page like a separate description of one of your projects. Since the baseof, single and list templates are basically empty I think, it could be a valuable addition. The template simply puts a logo on top of the page (recalling the home page) and renders the markdown content at the bottom. 

**Bugfix**: update references to static files.
In `header.html` an additional "/" should be added to the href value to correctly point to the files in static folder. E.g. if you create an additional single page content, say "projects/my-proj.md", it will include the partial "header.html" thanks to the baseof.html template. Nonetheless, without the "/", it would look for a static css file in "<siteurl>/projects/my-proj/css/main.css".