### PR TITLE
able to select site language

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ with $.Site.LanguageCode }}{{ . }}{{ else }}en-us{{ end }}">
 	{{ partial "header.html" . }}
 
 	<body>


### PR DESCRIPTION
#14 

In this way, you can change the site language you like by editing `config.toml`, otherwise "en-us" will be used.