### PR TITLE
Add rel-me to social links

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,7 +19,7 @@
 		<nav class="nav social">
 			<ul class="flat">
 				{{- range $index, $key := .Site.Params.Social -}}
-				<a href="{{ $key.url }}" title="{{ $key.name }}"><i data-feather="{{ $key.icon }}"></i></a>
+				<a href="{{ $key.url }}" rel="me" title="{{ $key.name }}"><i data-feather="{{ $key.icon }}"></i></a>
 				{{- end -}}
 				{{ if or (.Site.Params.blog) (.Site.Params.cv_name) }}
 				|


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are owned/controlled by the same person or organisation, and is used for authentication and proving site ownership in a variety of ways.