### PR TITLE
ENH: Enable links in subtitles

### DIFF
--- a/exampleSite/content/home/publications.md
+++ b/exampleSite/content/home/publications.md
@@ -8,7 +8,10 @@ content_type: 'publications'
 section_settings:
     show_section: true
     title: 'Recent Publications'
-    subtitle: 'Custom Subtitle: see my google scholar for the latest list'    
+    subtitle: |
+
+        Custom Subtitle: see my [google scholar](https://scholar.google.com/)
+        for the latest list
 ---
 
 home/publications.md

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@ NO CONTENT TYPE FOUND. Set content_type = "{{.Params.title | lower }}"
 
 {{ $subtitle := "" }}
 {{ if .Params.section_settings.subtitle }}
-{{ $subtitle = .Params.section_settings.subtitle }}
+{{ $subtitle = .Params.section_settings.subtitle | markdownify }}
 {{ end }}
 
 {{ if or $title (eq $content_type "about")}}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -21,6 +21,11 @@ h2 code {
   padding: 2px;
 }
 
+h6 a {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
 #TableOfContents ul {
     margin: auto;
     padding-left: 2%;


### PR DESCRIPTION
Thanks for the nice theme!

I wanted to be able to add links to the subtitle elements via markdown in the source. This seems straightforward enough to do with hugo `markdownify`. I also had to make a minor modification to the css file to get the spacing around `a` tags to look correct. I updated the `publications` page in the exampleSite to show off the new feature.